### PR TITLE
fix vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
     "Adriano Raiano <adriano@raiano.ch>"
   ],
   "dependencies": {
-    "cheerio": "^0.22.0",
+    "cheerio": "^1.0.0-rc.12",
     "is-stream": "^2.0.0",
-    "process.argv": "^0.1.0"
+    "process.argv": "^0.6.0"
   },
   "devDependencies": {
-    "jshint": "^2.10.2",
-    "mocha": "^6.1.4"
+    "jshint": "^2.13.6",
+    "mocha": "^10.2.0"
   },
   "homepage": "https://github.com/kawanet/rdotjson#readme",
   "jshintConfig": {


### PR DESCRIPTION
```
➜  rdotjson git:(master) ✗ npm audit
# npm audit report

nth-check  <2.0.1
Severity: high
Inefficient Regular Expression Complexity in nth-check - https://github.com/advisories/GHSA-rp65-9cf3-cjxr
fix available via `npm audit fix --force`
Will install cheerio@1.0.0-rc.12, which is a breaking change
node_modules/nth-check
  css-select  <=3.1.0
  Depends on vulnerable versions of nth-check
  node_modules/css-select
    cheerio  0.19.0 - 1.0.0-rc.3
    Depends on vulnerable versions of css-select
    node_modules/cheerio

3 high severity vulnerabilities
```

with newer dependencies:

```
➜  rdotjson git:(master) ✗ npm audit
found 0 vulnerabilities
```